### PR TITLE
Add Kafka producer and consumer scripts

### DIFF
--- a/src/consumer.py
+++ b/src/consumer.py
@@ -1,0 +1,24 @@
+from kafka import KafkaConsumer
+
+
+def process_messages(bootstrap_servers: str, topic: str) -> None:
+    """Consume messages from a Kafka topic and apply basic sentiment analysis.
+
+    Args:
+        bootstrap_servers (str): The Kafka server address.
+        topic (str): The topic to consume messages from.
+    """
+    consumer = KafkaConsumer(
+        topic,
+        bootstrap_servers=bootstrap_servers,
+        auto_offset_reset="earliest",
+    )
+    print("Listening for messages...")
+    for message in consumer:
+        text = message.value.decode("utf-8")
+        sentiment = "positive" if "avalanche" in text.lower() else "neutral"
+        print(f"Message: {text} | Sentiment: {sentiment}")
+
+
+if __name__ == "__main__":
+    process_messages("localhost:9092", "avalanche-topic")

--- a/src/producer.py
+++ b/src/producer.py
@@ -1,0 +1,22 @@
+import time
+from kafka import KafkaProducer
+
+
+def send_messages(bootstrap_servers: str, topic: str) -> None:
+    """Send a series of test messages to a Kafka topic.
+
+    Args:
+        bootstrap_servers (str): The Kafka server address.
+        topic (str): The topic to send messages to.
+    """
+    producer = KafkaProducer(bootstrap_servers=bootstrap_servers)
+    for i in range(10):
+        message = f"Message {i}: Avalanche incoming!"
+        producer.send(topic, message.encode("utf-8"))
+        print(f"Sent: {message}")
+        time.sleep(1)
+    producer.flush()
+
+
+if __name__ == "__main__":
+    send_messages("localhost:9092", "avalanche-topic")


### PR DESCRIPTION
This PR adds the initial Kafka producer and consumer scripts to the `exp-42-kafkaïftastic-avalanche` project. The producer sends test messages to a Kafka topic, while the consumer reads them and applies a basic sentiment analysis rule. These scripts form the core of the pipeline's data flow.

Changes:
- Added `src/producer.py` to send messages to a Kafka topic.
- Added `src/consumer.py` to consume messages and analyze sentiment.
- Scripts are PEP8/PEP257 compliant with type hints and docstrings.