### PR TITLE
Add Dockerfile with OCI labels and dynamic build date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Stage 1: Build dependencies
+FROM python:3.11-alpine AS builder
+
+WORKDIR /app
+COPY pyproject.toml poetry.lock* ./
+RUN apk add --no-cache gcc musl-dev && \
+    pip install poetry && \
+    poetry config virtualenvs.create false && \
+    poetry install --without dev --no-root
+
+# Stage 2: Runtime
+FROM python:3.11-alpine
+
+# Build argument for dynamic creation date
+ARG BUILD_DATE
+
+# OCI-compliant labels
+LABEL org.opencontainers.image.title="exp-42-kafkaïftastic-avalanche"
+LABEL org.opencontainers.image.description="A Kafka pipeline in an Alpine container with AI artifacts"
+LABEL org.opencontainers.image.version="0.1.0"
+LABEL org.opencontainers.image.authors="Brain-X <github@brain-x.io>"
+LABEL org.opencontainers.image.source="https://github.com/brainxio/exp-42-kafkaiftastic-avalanche"
+LABEL org.opencontainers.image.created=$BUILD_DATE
+
+WORKDIR /app
+COPY --from=builder /usr/local/lib/python3.11/site-packages/ /usr/local/lib/python3.11/site-packages/
+COPY src/ ./src/
+
+ENTRYPOINT ["python", "src/consumer.py"]


### PR DESCRIPTION
This PR adds a Dockerfile to the `exp-42-kafkaïftastic-avalanche` project, enabling containerization of the Kafka pipeline in an Alpine-based image. It uses a multi-stage build for efficiency and includes OCI-compliant labels, with a dynamic build date set via a build argument. Updated Poetry install command to use `--without dev` for compatibility.

Changes:
- Added `Dockerfile` with Alpine base and multi-stage build.
- Included OCI labels for title, description, version, authors, source, and a dynamic created date.
- Set default entrypoint to run the consumer script.