### PR TITLE
Add release workflow triggered by tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install Poetry
+        run: pip install poetry
+      - name: Install dependencies
+        run: poetry install --no-root
+      - name: Build Docker image
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          docker build --build-arg BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ") -t ghcr.io/brainxio/exp-42-kafkaiftastic-avalanche:$VERSION .
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push Docker image
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          docker push ghcr.io/brainxio/exp-42-kafkaiftastic-avalanche:$VERSION
+      - name: Generate mission artifact
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          cp artifacts/mission_template.json mission.json
+          sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" mission.json
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: mission.json
+          body: "Release $VERSION - See mission.json for details"


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for automated releases in the `exp-42-kafkaiftastic-avalanche` project. The workflow triggers on a tag push (e.g., v0.1.0), builds and pushes a Docker image to GHCR, generates a mission artifact based on a template, and creates a GitHub Release.

Changes:
- Added `.github/workflows/release.yml` with steps for building, pushing, artifact generation, and release creation.
- Configured to use tag versioning for Docker images and artifacts.
- Sets the foundation for future autonomous release enhancements.