### PR TITLE
Update consumer to keep running with poll-based message consumption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Ruff cahce
+.ruff_cache

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ install:
 	poetry install --no-root
 
 format:
-	poetry run black src/ tests/
+	poetry run black --line-length 79 src/ tests/
 
 lint:
-	poetry run black --check src/ tests/
+	poetry run black --check --line-length 79 src/ tests/
 	poetry run flake8 src/ tests/
 
 test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  zookeeper:
+    image: bitnami/zookeeper:latest
+    ports:
+      - "2181:2181"
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    volumes:
+      - zookeeper_data:/bitnami/zookeeper
+
+  kafka:
+    image: bitnami/kafka:latest
+    ports:
+      - "9092:9092"
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+    depends_on:
+      - zookeeper
+    healthcheck:
+      test: ["CMD", "kafka-topics.sh", "--list", "--bootstrap-server", "localhost:9092"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+    volumes:
+      - kafka_data:/bitnami/kafka
+
+  app:
+    image: ghcr.io/brainxio/exp-42-kafkaiftastic-avalanche:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - KAFKA_TOPIC=avalanche-topic
+    depends_on:
+      kafka:
+        condition: service_healthy
+    entrypoint: ["sh", "-c", "sleep 10 && python src/consumer.py"]
+
+volumes:
+  zookeeper_data:
+  kafka_data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,10 @@ build-backend = "poetry.core.masonry.api"
 flake8 = "^6.0"
 black = "^23.0"
 pytest = "^7.0"
+ruff = "^0.9.9"
 
+[tool.ruff]
+line-length = 79
+
+[tool.black]
+line-length = 79

--- a/src/consumer.py
+++ b/src/consumer.py
@@ -1,5 +1,12 @@
+import os
+import time
+import logging
 from kafka import KafkaConsumer
+from kafka.errors import NoBrokersAvailable
 
+# Setup basic logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 def process_messages(bootstrap_servers: str, topic: str) -> None:
     """Consume messages from a Kafka topic and apply basic sentiment analysis.
@@ -8,17 +15,45 @@ def process_messages(bootstrap_servers: str, topic: str) -> None:
         bootstrap_servers (str): The Kafka server address.
         topic (str): The topic to consume messages from.
     """
-    consumer = KafkaConsumer(
-        topic,
-        bootstrap_servers=bootstrap_servers,
-        auto_offset_reset="earliest",
-    )
-    print("Listening for messages...")
-    for message in consumer:
-        text = message.value.decode("utf-8")
-        sentiment = "positive" if "avalanche" in text.lower() else "neutral"
-        print(f"Message: {text} | Sentiment: {sentiment}")
+    max_retries = 20
+    retry_delay = 5  # seconds
+    for attempt in range(max_retries):
+        try:
+            logger.info(f"Attempting to connect to Kafka at {bootstrap_servers}, attempt {attempt + 1}/{max_retries}")
+            consumer = KafkaConsumer(
+                topic,
+                bootstrap_servers=bootstrap_servers,
+                auto_offset_reset="earliest",
+            )
+            logger.info("Connected to Kafka. Listening for messages...")
+            break
+        except NoBrokersAvailable as e:
+            logger.warning(f"No brokers available: {e}. Retrying in {retry_delay} seconds...")
+            if attempt == max_retries - 1:
+                logger.error("Max retries reached. Giving up.")
+                raise
+            time.sleep(retry_delay)
+    
+    # Continuous loop to keep consuming
+    while True:
+        try:
+            # Poll for messages with a timeout
+            msg_pack = consumer.poll(timeout_ms=1000)  # 1 second timeout
+            if not msg_pack:
+                logger.info("No messages received, waiting...")
+                continue
+            
+            for _, messages in msg_pack.items():
+                for message in messages:
+                    text = message.value.decode("utf-8")
+                    sentiment = "positive" if "avalanche" in text.lower() else "neutral"
+                    logger.info(f"Message: {text} | Sentiment: {sentiment}")
+        except Exception as e:
+            logger.error(f"Error while consuming messages: {e}")
+            time.sleep(retry_delay)  # Avoid tight loop on error
 
 
 if __name__ == "__main__":
-    process_messages("localhost:9092", "avalanche-topic")
+    bootstrap_servers = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+    topic = os.getenv("KAFKA_TOPIC", "avalanche-topic")
+    process_messages(bootstrap_servers, topic)

--- a/src/consumer.py
+++ b/src/consumer.py
@@ -21,7 +21,8 @@ def process_messages(bootstrap_servers: str, topic: str) -> None:
     for attempt in range(max_retries):
         try:
             logger.info(
-                f"Attempting to connect to Kafka at {bootstrap_servers}, attempt {attempt + 1}/{max_retries}"
+                f"Attempting to connect to Kafka at {bootstrap_servers}, "
+                f"attempt {attempt + 1}/{max_retries}"
             )
             consumer = KafkaConsumer(
                 topic,
@@ -32,7 +33,8 @@ def process_messages(bootstrap_servers: str, topic: str) -> None:
             break
         except NoBrokersAvailable as e:
             logger.warning(
-                f"No brokers available: {e}. Retrying in {retry_delay} seconds..."
+                f"No brokers available: {e}. Retrying in "
+                f"{retry_delay} seconds..."
             )
             if attempt == max_retries - 1:
                 logger.error("Max retries reached. Giving up.")
@@ -51,7 +53,11 @@ def process_messages(bootstrap_servers: str, topic: str) -> None:
             for _, messages in msg_pack.items():
                 for message in messages:
                     text = message.value.decode("utf-8")
-                    sentiment = "positive" if "avalanche" in text.lower() else "neutral"
+                    sentiment = (
+                        "positive"
+                        if "avalanche" in text.lower()
+                        else "neutral"
+                    )
                     logger.info(f"Message: {text} | Sentiment: {sentiment}")
         except Exception as e:
             logger.error(f"Error while consuming messages: {e}")

--- a/src/consumer.py
+++ b/src/consumer.py
@@ -8,6 +8,7 @@ from kafka.errors import NoBrokersAvailable
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 def process_messages(bootstrap_servers: str, topic: str) -> None:
     """Consume messages from a Kafka topic and apply basic sentiment analysis.
 
@@ -19,7 +20,9 @@ def process_messages(bootstrap_servers: str, topic: str) -> None:
     retry_delay = 5  # seconds
     for attempt in range(max_retries):
         try:
-            logger.info(f"Attempting to connect to Kafka at {bootstrap_servers}, attempt {attempt + 1}/{max_retries}")
+            logger.info(
+                f"Attempting to connect to Kafka at {bootstrap_servers}, attempt {attempt + 1}/{max_retries}"
+            )
             consumer = KafkaConsumer(
                 topic,
                 bootstrap_servers=bootstrap_servers,
@@ -28,12 +31,14 @@ def process_messages(bootstrap_servers: str, topic: str) -> None:
             logger.info("Connected to Kafka. Listening for messages...")
             break
         except NoBrokersAvailable as e:
-            logger.warning(f"No brokers available: {e}. Retrying in {retry_delay} seconds...")
+            logger.warning(
+                f"No brokers available: {e}. Retrying in {retry_delay} seconds..."
+            )
             if attempt == max_retries - 1:
                 logger.error("Max retries reached. Giving up.")
                 raise
             time.sleep(retry_delay)
-    
+
     # Continuous loop to keep consuming
     while True:
         try:
@@ -42,7 +47,7 @@ def process_messages(bootstrap_servers: str, topic: str) -> None:
             if not msg_pack:
                 logger.info("No messages received, waiting...")
                 continue
-            
+
             for _, messages in msg_pack.items():
                 for message in messages:
                     text = message.value.decode("utf-8")

--- a/src/producer.py
+++ b/src/producer.py
@@ -1,3 +1,4 @@
+import os
 import time
 from kafka import KafkaProducer
 
@@ -19,4 +20,6 @@ def send_messages(bootstrap_servers: str, topic: str) -> None:
 
 
 if __name__ == "__main__":
-    send_messages("localhost:9092", "avalanche-topic")
+    bootstrap_servers = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+    topic = os.getenv("KAFKA_TOPIC", "avalanche-topic")
+    send_messages(bootstrap_servers, topic)


### PR DESCRIPTION
This PR adds a `docker-compose.yml` file to `exp-42-kafkaiftastic-avalanche` to enable a local testing environment with Kafka, Zookeeper, and the application's container. It includes fixes for Kafka connection issues and ensures the consumer stays active.

Changes:
- Added `docker-compose.yml` with Zookeeper, Kafka, and app services.
- Updated `src/producer.py` and `src/consumer.py` to read Kafka settings from environment variables.
- Enhanced `consumer.py` with retry logic, logging, and poll-based consumption to keep it running.
- Added healthcheck to Kafka and a 10-second startup delay to the app service in docker-compose.
- Simplifies local testing and ensures reliable Kafka connectivity and continuous operation.