### PR TITLE
Add ruff to CI linting for consistent workflow settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         run: |
           poetry run black --check src/ tests/
           poetry run flake8 src/ tests/
+          poetry run ruff check src/ tests/
 
   test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ format:
 lint:
 	poetry run black --check --line-length 79 src/ tests/
 	poetry run flake8 src/ tests/
+	poetry run ruff check src/ tests/
 
 test:
 	poetry run pytest tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,20 @@ black = "^23.0"
 pytest = "^7.0"
 ruff = "^0.9.9"
 
-[tool.ruff]
-line-length = 79
-
 [tool.black]
 line-length = 79
+skip-string-normalization = false  # Forceer consistente stringquotes (geen uitzonderingen)
+target-version = ['py39']  # Stel een specifieke Python-versie in voor consistente opmaak
 
 [tool.flake8]
 max-line-length = 79
+extend-ignore = []  # Geen extra uitzonderingen
+select = "E,F,W"  # Consistente regels met ruff
+
+[tool.ruff]
+line-length = 79
+fix = true
+
+[tool.ruff.lint]
+select = ["E", "F", "W"]
+ignore = []


### PR DESCRIPTION
This PR ensures consistent linting rules between local development and CI workflows. The following changes have been made:

1. Added strict linting rules in `pyproject.toml` for `black`, `ruff`, and `flake8` with a uniform line length of 79 characters and no exceptions.
2. Updated `Makefile` to standardize local linting with `black`, `flake8`, and `ruff`.
3. Added `ruff` to the `lint` job in `ci.yml` to ensure the same checks are performed in CI as locally.

This guarantees fully predictable behavior of the linting tools, both locally and in GitHub Actions. Upon approval, this branch can be merged into `main`.